### PR TITLE
Fixed schema exports for drizzle-graphql to work properly

### DIFF
--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -1,3 +1,4 @@
-export { plates, users, presets } from "./schemas";
+export { plates, platesToPresets, presets, recipes, users } from "./schemas";
 
 export { db } from "./connection";
+

--- a/src/services/db/schemas/index.ts
+++ b/src/services/db/schemas/index.ts
@@ -1,5 +1,8 @@
-export { users } from "./users";
 export { plates } from "./plates";
+export { platesToPresets } from './plates-to-presets';
 export { presets } from "./presets";
+export { recipes } from './recipes';
+export { users } from "./users";
 
 export * from "./relations";
+


### PR DESCRIPTION
The issue you had [here](https://twitter.com/shashkov0/status/1782142680119591224?t=22UQu6Naxqc4Z32y3afXyA) was caused by absence of tables used in relations in schema you've constructed the drizzle instance with. Adding tables to the schema should fix it. 